### PR TITLE
Load entire module with dependencies

### DIFF
--- a/generate-docs.js
+++ b/generate-docs.js
@@ -7,7 +7,7 @@ const folder = path.resolve(__dirname, "docs");
 fs.mkdirSync(folder);
 
 const ts = new reflect.TypeSystem();
-ts.loadFile(path.resolve(__dirname, ".jsii")).then(() => {
+ts.load(path.resolve(__dirname)).then(() => {
   function createDocs(language) {
     const docs = new Documentation({
       assembly: ts.findAssembly("jsii-workbench"),


### PR DESCRIPTION
According to the `jsii-reflect` [docs](https://github.com/aws/jsii/tree/main/packages/jsii-reflect#loading-assemblies) this will load the module and its dependencies. Confirmed it's working with `cdktf` and `constructs` as dependencies.